### PR TITLE
0.7.9

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+0.7.9
+
+* Channel and listener id generation now relies on uuid4
+
 0.7.7
 
 * Now SocketServer starts correspondant listener on 'l' command

--- a/eric_sse/__init__.py
+++ b/eric_sse/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from logging import getLogger, StreamHandler, Logger
-
+from uuid import uuid4
 
 def get_logger() -> Logger:
     logger = getLogger(__name__)
@@ -14,3 +14,6 @@ def get_logger() -> Logger:
         logger.addHandler(handler)
 
     return logger
+
+def generate_uuid() -> str:
+    return str(uuid4())

--- a/eric_sse/entities.py
+++ b/eric_sse/entities.py
@@ -69,7 +69,7 @@ class AbstractChannel(ABC):
             stream_delay_seconds: int = 0,
             queues_factory: AbstractMessageQueueFactory | None = None
     ):
-        self.id = eric_sse.generate_uuid()
+        self.id: str = eric_sse.generate_uuid()
         self.stream_delay_seconds = stream_delay_seconds
 
         self.__listeners: dict[str: MessageQueueListener] = {}

--- a/eric_sse/entities.py
+++ b/eric_sse/entities.py
@@ -15,21 +15,15 @@ MESSAGE_TYPE_CLOSED = '_eric_channel_closed'
 MESSAGE_TYPE_END_OF_STREAM = '_eric_channel_eof'
 MESSAGE_TYPE_INTERNAL_ERROR = '_eric_error'
 
-_LISTENERS_NEXT_ID_LOCK = Lock()
-
 class MessageQueueListener(ABC):
     """
     Base class for listeners.
 
     Optionally you can override on_message method if you need to inject code at message delivery time.
     """
-    NEXT_ID = 1
 
     def __init__(self):
-        self.id: str | None = None
-        with _LISTENERS_NEXT_ID_LOCK:
-            self.id: str = str(MessageQueueListener.NEXT_ID)
-            MessageQueueListener.NEXT_ID += 1
+        self.id: str = eric_sse.generate_uuid()
         self.__is_running: bool = False
 
     async def start(self) -> None:
@@ -70,18 +64,12 @@ class AbstractChannel(ABC):
 
     :param eric_sse.queue.AbstractMessageQueueFactory queues_factory:
     """
-    NEXT_ID = 1
-
     def __init__(
             self,
             stream_delay_seconds: int = 0,
             queues_factory: AbstractMessageQueueFactory | None = None
     ):
-        logger.debug(f'Creating channel {AbstractChannel.NEXT_ID}')
-        with Lock():
-            self.id: str = str(AbstractChannel.NEXT_ID)
-            AbstractChannel.NEXT_ID += 1
-
+        self.id = eric_sse.generate_uuid()
         self.stream_delay_seconds = stream_delay_seconds
 
         self.__listeners: dict[str: MessageQueueListener] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "eric-sse"
 description = "A lightweight message dispatcher based on SSE protocol data transfer objects format"
 requires-python = ">=3.10, <3.12"
-version = "0.7.8"
+version = "0.7.9"
 authors = [
     {name = "Luca Stretti", email = "laxertu@gmail.com"}
 ]

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -82,10 +82,10 @@ class ClientIntegrationTestCase(IsolatedAsyncioTestCase):
     async def test_integration(self):
 
         channel_id = await self.sut.create_channel()
-        self.assertTrue(len(channel_id) > 0)
+        self.assertEqual(len(channel_id), 36)
 
         listener_id = await self.sut.register(channel_id)
-        self.assertTrue(len(listener_id) > 0)
+        self.assertEqual(len(listener_id), 36)
 
         error_message = await self.sut.register('2')
         self.assertTrue('InvalidChannelException' in error_message)

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -82,10 +82,10 @@ class ClientIntegrationTestCase(IsolatedAsyncioTestCase):
     async def test_integration(self):
 
         channel_id = await self.sut.create_channel()
-        self.assertTrue(int(channel_id) > 0)
+        self.assertTrue(len(channel_id) > 0)
 
         listener_id = await self.sut.register(channel_id)
-        self.assertTrue(int(listener_id) > 0)
+        self.assertTrue(len(listener_id) > 0)
 
         error_message = await self.sut.register('2')
         self.assertTrue('InvalidChannelException' in error_message)

--- a/test/test_sse_channel.py
+++ b/test/test_sse_channel.py
@@ -9,8 +9,7 @@ from test.mock.listener import MessageQueueListenerMock
 class SSEStreamTestCase(IsolatedAsyncioTestCase):
     def setUp(self):
         self.sut = SSEChannel()
-        SSEChannel.NEXT_ID = 1
-        MessageQueueListener.NEXT_ID = 1
+
 
     async def test_sse_channel_default_output(self):
         # setup


### PR DESCRIPTION
* Channel and listener id generation now relies on uuid4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Channel and listener IDs are now generated using UUIDs for improved uniqueness.
- **Bug Fixes**
  - Updated tests to validate the new UUID-based IDs appropriately.
- **Documentation**
  - Added a changelog entry for version 0.7.9 noting the switch to UUID-based ID generation.
- **Chores**
  - Updated the project version to 0.7.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->